### PR TITLE
mark-devkit: Bump virtual/libc-2

### DIFF
--- a/virtual/libc/libc-2.ebuild
+++ b/virtual/libc/libc-2.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for C library"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND="elibc_glibc? ( sys-libs/glibc )
+	elibc_musl? ( sys-libs/musl )
+	elibc_uclibc? ( sys-libs/uclibc-ng )
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libc-2 for branch mark-unstable by mark-bot