### PR TITLE
mark-devkit: Bump virtual/tmpfiles-3

### DIFF
--- a/virtual/tmpfiles/tmpfiles-3.ebuild
+++ b/virtual/tmpfiles/tmpfiles-3.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual to select between different tmpfiles.d handlers"
+SLOT="0"
+KEYWORDS="*"
+IUSE="systemd"
+RDEPEND="!systemd? ( sys-apps/systemd-tmpfiles )
+	systemd? ( sys-apps/systemd )
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/tmpfiles-3 for branch mark-unstable by mark-bot