### PR TITLE
mark-devkit: Bump virtual/acl-1

### DIFF
--- a/virtual/acl/acl-1.ebuild
+++ b/virtual/acl/acl-1.ebuild
@@ -1,0 +1,13 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for acl support (sys/acl.h)"
+SLOT="0"
+KEYWORDS="*"
+IUSE="static-libs"
+RDEPEND="sys-apps/acl[static-libs?]
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/acl-1 for branch mark-unstable by mark-bot