### PR TITLE
mark-devkit: Bump virtual/libiconv-1

### DIFF
--- a/virtual/libiconv/libiconv-1.ebuild
+++ b/virtual/libiconv/libiconv-1.ebuild
@@ -1,0 +1,9 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for the GNU conversion library"
+SLOT="0"
+KEYWORDS="*"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libiconv-1 for branch mark-unstable by mark-bot