### PR TITLE
mark-devkit: Bump virtual/libelf-4

### DIFF
--- a/virtual/libelf/libelf-4.ebuild
+++ b/virtual/libelf/libelf-4.ebuild
@@ -1,0 +1,12 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for libelf.so.1 provider dev-libs/elfutils"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND="dev-libs/elfutils
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libelf-4 for branch mark-iii by mark-bot