### PR TITLE
mark-devkit: Bump virtual/libintl-1

### DIFF
--- a/virtual/libintl/libintl-1.ebuild
+++ b/virtual/libintl/libintl-1.ebuild
@@ -1,0 +1,9 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for the GNU Internationalization Library"
+SLOT="0"
+KEYWORDS="*"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libintl-1 for branch mark-xl by mark-bot