### PR TITLE
mark-devkit: Bump virtual/libffi-3.5.1

### DIFF
--- a/virtual/libffi/libffi-3.5.1.ebuild
+++ b/virtual/libffi/libffi-3.5.1.ebuild
@@ -1,0 +1,13 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="A virtual for the Foreign Function Interface implementation"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND=">=dev-libs/libffi-3.5.1
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libffi-3.5.1 for branch mark-xl by mark-bot