### PR TITLE
mark-devkit: [mark-31] Bump dev-libs/icu-78.1-r1

### DIFF
--- a/dev-libs/icu/icu-78.1-r1.ebuild
+++ b/dev-libs/icu/icu-78.1-r1.ebuild
@@ -15,7 +15,7 @@ IUSE="debug doc examples static-libs"
 BDEPEND="${PYTHON_DEPS}
 	sys-devel/autoconf-archive
 	virtual/pkgconfig
-	doc? ( app-text/doxygen[dot] )
+	doc? ( app-doc/doxygen[dot] )
 	
 "
 S="${WORKDIR}/icu/source"


### PR DESCRIPTION
Automatic bump of package dev-libs/icu-78.1-r1 for branch mark-31 by mark-bot