### PR TITLE
sys-apps/acl needs sys-apps/attr to compile

### DIFF
--- a/sys-apps/acl/acl-2.3.2.ebuild
+++ b/sys-apps/acl/acl-2.3.2.ebuild
@@ -10,6 +10,8 @@ LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="*"
 IUSE="nls static-libs"
+
+BDEPEND="sys-apps/attr"
 DEPEND="nls? ( sys-devel/gettext )
 	
 "


### PR DESCRIPTION
reported on https://github.com/macaroni-os/mark-issues/issues/671