### PR TITLE
mark-devkit: [mark-iii] Bump sys-apps/acl-2.3.2-r1

### DIFF
--- a/sys-apps/acl/acl-2.3.2-r1.ebuild
+++ b/sys-apps/acl/acl-2.3.2-r1.ebuild
@@ -10,6 +10,8 @@ LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="*"
 IUSE="nls static-libs"
+
+BDEPEND="sys-apps/attr"
 DEPEND="nls? ( sys-devel/gettext )
 	
 "


### PR DESCRIPTION
Automatic bump of package sys-apps/acl-2.3.2-r1 for branch mark-iii by mark-bot