### PR TITLE
mark-devkit: [mark-unstable] Bump virtual/libffi-3.6.0

### DIFF
--- a/virtual/libffi/libffi-3.6.0.ebuild
+++ b/virtual/libffi/libffi-3.6.0.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="A virtual for the Foreign Function Interface implementation"
+HOMEPAGE="http://sourceware.org/libffi"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND=">=dev-libs/libffi-3.6.0
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libffi-3.6.0 for branch mark-unstable by mark-bot