### PR TITLE
mark-devkit: [mark-unstable] Bump virtual/libc-3

### DIFF
--- a/virtual/libc/libc-3.ebuild
+++ b/virtual/libc/libc-3.ebuild
@@ -1,0 +1,20 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="Virtual for C library"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND="elibc_glibc? (
+	  >=sys-libs/glibc-2.41
+	  sys-apps/locale-gen
+	)
+	elibc_musl? ( sys-libs/musl )
+	elibc_uclibc? ( sys-libs/uclibc-ng )
+	
+"
+DEPEND="${RDEPEND}
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libc-3 for branch mark-unstable by mark-bot